### PR TITLE
Use built-in rollup bin for building post-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup -c",
-    "watch": "rollup -cw",
+    "build": "./node_modules/.bin/rollup -c",
+    "watch": "./node_modules/.bin/rollup -cw",
     "postinstall": "yarn build"
   },
   "devDependencies": {


### PR DESCRIPTION
To not have any weird errors in CI building